### PR TITLE
Update mods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plonk_gadgets"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["CPerezz <c.perezbaro@gmail.com>", "Victor Lopez <vhrlopes@gmail.com>"]
 edition = "2018"
 

--- a/src/gadgets/scalar/mod.rs
+++ b/src/gadgets/scalar/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod range;
-pub(crate) mod scalar;
+pub mod range;
+pub mod scalar;

--- a/src/gadgets/scalar/range.rs
+++ b/src/gadgets/scalar/range.rs
@@ -176,7 +176,7 @@ pub fn single_complex_rangeproof_gadget(
 ///
 /// Checks that `min_range <= witness < max_range` returning a boolean `Variable` as a result
 /// where `1 = holds` and `0 = Does not hold`.
-fn complete_complex_rangeproof_gadget(
+pub fn complete_complex_rangeproof_gadget(
     composer: &mut StandardComposer,
     witness: BlsScalar,
     witness_var: Variable,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
-pub mod gadgets;
+mod gadgets;
+pub use gadgets::scalar::range as range_gadgets;
+pub use gadgets::scalar::scalar as scalar_gadgets;


### PR DESCRIPTION
The structure on which the modules are defined is quite
verbose.

Therefore we re-exported the gadgets more precisely in
`lib.rs` to facilitate the imports on libs that depend on
this one.

Bump to `v0.2.0`