### PR TITLE
Adapt the CI to the new `Canon` trait used in plonk

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -29,26 +29,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
-
-  test_stable:
-    name: Stable tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
 
   test_nightly:
     name: Nightly tests
@@ -73,7 +58,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-10-25
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
Since `Canon` implies the usage of `min_const_generics` feature,
we need to adapt the CI of the repos in order to not complain
with this nightly features.