### PR TITLE
Update version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plonk_gadgets"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["CPerezz <carlos@dusk.network>", "Kevaundray Wedderburn <kev@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 


### PR DESCRIPTION
Due to the recent change in the BLS scalar import. A new version must be released. The Cargo change is made in this
commit.

This closes #31 