### PR TITLE
Remove `anyhow` & `thiserror` from crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Add
-- Add `std-plonk` feature to crate [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+- Add `std` feature to crate [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
 
 ### Change
 - Change crate to be `no_std` by default [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Add
+- Add `std-plonk` feature to crate [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+
+### Change
+- Change crate to be `no_std` by default [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+- Update `rand` from v0.7 to v0.8 [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+
 ### Remove
 - Remove `anyhow` and `thiserror`. [#39](https://github.com/dusk-network/plonk_gadgets/issues/39)
+- Remove `rand_core` from dev-deps [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
 
 ## [v0.5.0] - 13-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Change
 - Change crate to be `no_std` by default [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
-- Update `rand` from v0.7 to v0.8 [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+- Update `rand` from `v0.7` to `v0.8` [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
 
 ### Remove
 - Remove `anyhow` and `thiserror`. [#39](https://github.com/dusk-network/plonk_gadgets/issues/39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Remove
+- Remove `anyhow` and `thiserror`. [#39](https://github.com/dusk-network/plonk_gadgets/issues/39)
+
 ## [v0.5.0] - 13-01-21
 
 ### Change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ exclude = [
 
 [dependencies]
 dusk-bytes = "0.1"
-dusk-plonk = "0.8.0-rc.1"
+dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["alloc"]}
 
 [dev-dependencies]
 rand = "0.8"
-rand_core = "0.5"
+
+[features]
+std-plonk = [
+    "dusk-plonk/std"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ exclude = [
 [dependencies]
 dusk-bytes = "0.1"
 dusk-plonk = "0.8.0-rc.1"
-anyhow = "1"
-thiserror = "1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["all
 rand = "0.8"
 
 [features]
-std-plonk = [
+std = [
     "dusk-plonk/std"
 ]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,13 +8,11 @@
 //!
 //! Includes the definitions of all of the possible errors that the gadgets
 //! might encounter with toghether with it's display message implementations.
-use thiserror::Error;
 
 /// Represents an error during the execution of one of the library gagets.
-#[derive(Error, Debug)]
-pub enum GadgetErrors {
+#[derive(Debug)]
+pub enum Error {
     /// Error returned when we try to compute the inverse of a number which is
     /// non-QR (doesn't have an inverse inside of the field)
-    #[error("error on the computation of an inverse")]
     NonExistingInverse,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@
 #![deny(unsafe_code)]
 
 pub(crate) mod allocated_scalar;
-pub(crate) mod errors;
+pub mod errors;
 pub mod range;
 pub mod scalar;
 
-pub use crate::errors::GadgetErrors;
+pub use crate::errors::Error;
 pub use allocated_scalar::AllocatedScalar;
 pub use range as RangeGadgets;
 pub use scalar as ScalarGadgets;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![no_std]
+
+extern crate alloc;
 
 pub(crate) mod allocated_scalar;
 pub mod errors;

--- a/src/range.rs
+++ b/src/range.rs
@@ -191,6 +191,7 @@ fn num_bits_closest_power_of_two(scalar: BlsScalar) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn counting_scalar_bits() {
@@ -228,6 +229,6 @@ mod tests {
 
         verifier.preprocess(&ck)?;
 
-        verifier.verify(&proof, &vk, &alloc::vec![BlsScalar::zero()])
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -12,6 +12,7 @@
 //! since it will introduce less constraints to your CS.
 
 use super::{scalar::maybe_equal, AllocatedScalar};
+use alloc::vec::Vec;
 use dusk_bytes::Serializable;
 use dusk_plonk::prelude::*;
 
@@ -227,6 +228,6 @@ mod tests {
 
         verifier.preprocess(&ck)?;
 
-        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
+        verifier.verify(&proof, &vk, &alloc::vec![BlsScalar::zero()])
     }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -190,7 +190,6 @@ fn num_bits_closest_power_of_two(scalar: BlsScalar) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::{Error, Result};
 
     #[test]
     fn counting_scalar_bits() {
@@ -228,8 +227,6 @@ mod tests {
 
         verifier.preprocess(&ck)?;
 
-        verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .map_err(|e| anyhow::anyhow!(e))
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -9,8 +9,7 @@
 //! This module actually contains conditional selection implementations as
 //! well as equalty-checking gadgets.
 use super::AllocatedScalar;
-use crate::errors::GadgetErrors;
-use anyhow::{Error, Result};
+use crate::Error as GadgetsError;
 use dusk_plonk::prelude::*;
 
 /// Conditionally selects the value provided or a zero instead.
@@ -65,7 +64,7 @@ pub fn is_non_zero(
     composer: &mut StandardComposer,
     var: Variable,
     value_assigned: BlsScalar,
-) -> Result<(), Error> {
+) -> Result<(), GadgetsError> {
     // Add original scalar which is equal to `var`.
     let var_assigned = composer.add_input(value_assigned);
     // Constrain `var` to actually be equal to the `var_assigment` provided.
@@ -77,7 +76,7 @@ pub fn is_non_zero(
         // Safe to unwrap here.
         inv = composer.add_input(inverse.unwrap());
     } else {
-        return Err(GadgetErrors::NonExistingInverse.into());
+        return Err(GadgetsError::NonExistingInverse);
     }
 
     // Var * Inv(Var) = 1

--- a/tests/range_gadgets_tests.rs
+++ b/tests/range_gadgets_tests.rs
@@ -4,204 +4,198 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-extern crate anyhow;
 extern crate dusk_plonk;
 extern crate plonk_gadgets;
+use dusk_plonk::prelude::*;
+use plonk_gadgets::AllocatedScalar;
+use plonk_gadgets::RangeGadgets::*;
 
-#[cfg(test)]
-mod tests {
-    use anyhow::{Error, Result};
-    use dusk_plonk::prelude::*;
-    use plonk_gadgets::AllocatedScalar;
-    use plonk_gadgets::RangeGadgets::*;
+fn max_bound_gadget(
+    composer: &mut StandardComposer,
+    max_range: BlsScalar,
+    witness: BlsScalar,
+    result: bool,
+) {
+    let witness = AllocatedScalar::allocate(composer, witness);
+    let (res, _) = max_bound(composer, max_range, witness);
 
-    fn max_bound_gadget(
-        composer: &mut StandardComposer,
+    let mut outcome = BlsScalar::zero();
+    if result {
+        outcome = BlsScalar::one()
+    }
+    composer.constrain_to_constant(res, outcome, None);
+}
+
+fn range_check_gadget(
+    composer: &mut StandardComposer,
+    max_range: BlsScalar,
+    min_range: BlsScalar,
+    witness: BlsScalar,
+    result: bool,
+) {
+    let witness = AllocatedScalar::allocate(composer, witness);
+    let res = range_check(composer, min_range, max_range, witness);
+
+    let mut outcome = BlsScalar::zero();
+    if result {
+        outcome = BlsScalar::one()
+    }
+    composer.constrain_to_constant(res, outcome, None);
+}
+
+#[test]
+fn max_bound_test() -> Result<(), Error> {
+    // Generate Composer & Public Parameters
+    let pub_params = PublicParameters::setup(1 << 11, &mut rand::thread_rng())?;
+    let (ck, vk) = pub_params.trim(1 << 10)?;
+
+    struct TestCase {
         max_range: BlsScalar,
         witness: BlsScalar,
-        result: bool,
-    ) {
-        let witness = AllocatedScalar::allocate(composer, witness);
-        let (res, _) = max_bound(composer, max_range, witness);
-
-        let mut outcome = BlsScalar::zero();
-        if result {
-            outcome = BlsScalar::one()
-        }
-        composer.constrain_to_constant(res, outcome, None);
+        expected_result: bool,
     }
+    let test_cases = vec![
+        TestCase {
+            max_range: BlsScalar::from(2u64).pow(&[128u64, 0, 0, 0]) - BlsScalar::one(),
+            witness: BlsScalar::from(2u64).pow(&[127u64, 0, 0, 0]),
+            expected_result: true,
+        },
+        TestCase {
+            max_range: BlsScalar::from(200u64),
+            witness: BlsScalar::from(100u64),
+            expected_result: true,
+        },
+        TestCase {
+            max_range: BlsScalar::from(100u64),
+            witness: BlsScalar::from(200u64),
+            expected_result: false,
+        },
+        TestCase {
+            max_range: BlsScalar::from(2u64).pow(&[128u64, 0, 0, 0]) - BlsScalar::one(),
+            witness: BlsScalar::from(2u64).pow(&[130u64, 0, 0, 0]),
+            expected_result: false,
+        },
+    ];
 
-    fn range_check_gadget(
-        composer: &mut StandardComposer,
+    for case in test_cases.into_iter() {
+        // Proving
+        let mut prover = Prover::default();
+
+        max_bound_gadget(
+            prover.mut_cs(),
+            case.max_range,
+            case.witness,
+            case.expected_result,
+        );
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::default();
+        max_bound_gadget(
+            verifier.mut_cs(),
+            case.max_range,
+            case.witness,
+            case.expected_result,
+        );
+        verifier.preprocess(&ck)?;
+        assert!(verifier
+            .verify(&proof, &vk, &vec![BlsScalar::zero()])
+            .is_ok());
+    }
+    Ok(())
+}
+#[test]
+fn range_check_test() -> Result<(), Error> {
+    // Generate Composer & Public Parameters
+    let pub_params = PublicParameters::setup(1 << 11, &mut rand::thread_rng())?;
+    let (ck, vk) = pub_params.trim(1 << 10)?;
+
+    struct TestCase {
         max_range: BlsScalar,
         min_range: BlsScalar,
         witness: BlsScalar,
-        result: bool,
-    ) {
-        let witness = AllocatedScalar::allocate(composer, witness);
-        let res = range_check(composer, min_range, max_range, witness);
+        expected_result: bool,
+    }
+    let test_cases = vec![
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(50_001u64),
+            expected_result: true,
+        },
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(250_001u64),
+            expected_result: false,
+        },
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(250_000u64),
+            expected_result: false,
+        },
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(249_000u64),
+            expected_result: true,
+        },
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(50_000u64),
+            expected_result: true,
+        },
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(49_999u64),
+            expected_result: false,
+        },
+        TestCase {
+            min_range: BlsScalar::from(2u64).pow(&[126u64, 0, 0, 0]),
+            max_range: BlsScalar::from(2u64).pow(&[127u64, 0, 0, 0]) + BlsScalar::one(),
+            witness: BlsScalar::from(2u64).pow(&[127u64, 0, 0, 0]) - BlsScalar::one(),
+            expected_result: true,
+        },
+        TestCase {
+            min_range: BlsScalar::from(50_000u64),
+            max_range: BlsScalar::from(250_000u64),
+            witness: BlsScalar::from(18_598u64),
+            expected_result: false,
+        },
+    ];
 
-        let mut outcome = BlsScalar::zero();
-        if result {
-            outcome = BlsScalar::one()
-        }
-        composer.constrain_to_constant(res, outcome, None);
+    for case in test_cases.into_iter() {
+        // Proving
+        let mut prover = Prover::default();
+
+        range_check_gadget(
+            prover.mut_cs(),
+            case.max_range,
+            case.min_range,
+            case.witness,
+            case.expected_result,
+        );
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::default();
+        range_check_gadget(
+            verifier.mut_cs(),
+            case.max_range,
+            case.min_range,
+            case.witness,
+            case.expected_result,
+        );
+        verifier.preprocess(&ck)?;
+        assert!(verifier
+            .verify(&proof, &vk, &vec![BlsScalar::zero()])
+            .is_ok());
     }
 
-    #[test]
-    fn max_bound_test() -> Result<(), Error> {
-        // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 11, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 10)?;
-
-        struct TestCase {
-            max_range: BlsScalar,
-            witness: BlsScalar,
-            expected_result: bool,
-        }
-        let test_cases = vec![
-            TestCase {
-                max_range: BlsScalar::from(2u64).pow(&[128u64, 0, 0, 0]) - BlsScalar::one(),
-                witness: BlsScalar::from(2u64).pow(&[127u64, 0, 0, 0]),
-                expected_result: true,
-            },
-            TestCase {
-                max_range: BlsScalar::from(200u64),
-                witness: BlsScalar::from(100u64),
-                expected_result: true,
-            },
-            TestCase {
-                max_range: BlsScalar::from(100u64),
-                witness: BlsScalar::from(200u64),
-                expected_result: false,
-            },
-            TestCase {
-                max_range: BlsScalar::from(2u64).pow(&[128u64, 0, 0, 0]) - BlsScalar::one(),
-                witness: BlsScalar::from(2u64).pow(&[130u64, 0, 0, 0]),
-                expected_result: false,
-            },
-        ];
-
-        for case in test_cases.into_iter() {
-            // Proving
-            let mut prover = Prover::default();
-
-            max_bound_gadget(
-                prover.mut_cs(),
-                case.max_range,
-                case.witness,
-                case.expected_result,
-            );
-            prover.preprocess(&ck)?;
-            let proof = prover.prove(&ck)?;
-
-            // Verification
-            let mut verifier = Verifier::default();
-            max_bound_gadget(
-                verifier.mut_cs(),
-                case.max_range,
-                case.witness,
-                case.expected_result,
-            );
-            verifier.preprocess(&ck)?;
-            assert!(verifier
-                .verify(&proof, &vk, &vec![BlsScalar::zero()])
-                .is_ok());
-        }
-        Ok(())
-    }
-    #[test]
-    fn range_check_test() -> Result<(), Error> {
-        // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 11, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 10)?;
-
-        struct TestCase {
-            max_range: BlsScalar,
-            min_range: BlsScalar,
-            witness: BlsScalar,
-            expected_result: bool,
-        }
-        let test_cases = vec![
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(50_001u64),
-                expected_result: true,
-            },
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(250_001u64),
-                expected_result: false,
-            },
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(250_000u64),
-                expected_result: false,
-            },
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(249_000u64),
-                expected_result: true,
-            },
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(50_000u64),
-                expected_result: true,
-            },
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(49_999u64),
-                expected_result: false,
-            },
-            TestCase {
-                min_range: BlsScalar::from(2u64).pow(&[126u64, 0, 0, 0]),
-                max_range: BlsScalar::from(2u64).pow(&[127u64, 0, 0, 0]) + BlsScalar::one(),
-                witness: BlsScalar::from(2u64).pow(&[127u64, 0, 0, 0]) - BlsScalar::one(),
-                expected_result: true,
-            },
-            TestCase {
-                min_range: BlsScalar::from(50_000u64),
-                max_range: BlsScalar::from(250_000u64),
-                witness: BlsScalar::from(18_598u64),
-                expected_result: false,
-            },
-        ];
-
-        for case in test_cases.into_iter() {
-            // Proving
-            let mut prover = Prover::default();
-
-            range_check_gadget(
-                prover.mut_cs(),
-                case.max_range,
-                case.min_range,
-                case.witness,
-                case.expected_result,
-            );
-            prover.preprocess(&ck)?;
-            let proof = prover.prove(&ck)?;
-
-            // Verification
-            let mut verifier = Verifier::default();
-            range_check_gadget(
-                verifier.mut_cs(),
-                case.max_range,
-                case.min_range,
-                case.witness,
-                case.expected_result,
-            );
-            verifier.preprocess(&ck)?;
-            assert!(verifier
-                .verify(&proof, &vk, &vec![BlsScalar::zero()])
-                .is_ok());
-        }
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/tests/scalar_gadgets_tests.rs
+++ b/tests/scalar_gadgets_tests.rs
@@ -4,242 +4,233 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-extern crate anyhow;
 extern crate dusk_plonk;
 extern crate plonk_gadgets;
 
-#[cfg(test)]
-mod tests {
-    use anyhow::{Error, Result};
-    use dusk_plonk::prelude::*;
-    use plonk_gadgets::AllocatedScalar;
-    use plonk_gadgets::ScalarGadgets::*;
+use dusk_plonk::prelude::*;
+use plonk_gadgets::{AllocatedScalar, Error as GadgetError, ScalarGadgets::*};
 
-    #[test]
-    fn test_maybe_equal() -> Result<(), Error> {
-        // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 10, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 9)?;
+#[test]
+fn test_maybe_equal() -> Result<(), Error> {
+    // Generate Composer & Public Parameters
+    let pub_params = PublicParameters::setup(1 << 10, &mut rand::thread_rng())?;
+    let (ck, vk) = pub_params.trim(1 << 9)?;
 
-        let is_equal_gadget =
-            |composer: &mut StandardComposer, num_1: u64, num_2: u64, result: bool| {
-                let a = AllocatedScalar::allocate(composer, BlsScalar::from(num_1));
-                let b = AllocatedScalar::allocate(composer, BlsScalar::from(num_2));
+    let is_equal_gadget =
+        |composer: &mut StandardComposer, num_1: u64, num_2: u64, result: bool| {
+            let a = AllocatedScalar::allocate(composer, BlsScalar::from(num_1));
+            let b = AllocatedScalar::allocate(composer, BlsScalar::from(num_2));
 
-                let bit = maybe_equal(composer, a, b);
+            let bit = maybe_equal(composer, a, b);
 
-                let mut outcome = BlsScalar::zero();
-                if result {
-                    outcome = BlsScalar::one()
-                }
-                composer.constrain_to_constant(bit, outcome, None);
-            };
-
-        // Proving
-        // Should pass as 100 == 100
-        let mut prover = Prover::new(b"testing");
-        is_equal_gadget(prover.mut_cs(), 100, 100, true);
-
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
-
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        is_equal_gadget(verifier.mut_cs(), 0, 0, true);
-
-        verifier.preprocess(&ck).expect("Preprocessing error");
-        assert!(verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .is_ok());
-
-        // Proving
-        // Should fail as 20 != 3330
-        let mut prover = Prover::new(b"testing");
-        is_equal_gadget(prover.mut_cs(), 20, 3330, false);
-
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
-
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        is_equal_gadget(verifier.mut_cs(), 0, 0, false);
-
-        verifier.preprocess(&ck)?;
-        assert!(verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .is_ok());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_conditionally_select_0() -> Result<(), Error> {
-        // The circuit closure runs the conditionally_select_zero fn and constraints the result
-        // to actually be 0
-        let circuit = |composer: &mut StandardComposer, value: BlsScalar, selector: BlsScalar| {
-            let value = composer.add_input(value);
-            let selector = composer.add_input(selector);
-            let res = conditionally_select_zero(composer, value, selector);
-            composer.constrain_to_constant(res, BlsScalar::zero(), None);
+            let mut outcome = BlsScalar::zero();
+            if result {
+                outcome = BlsScalar::one()
+            }
+            composer.constrain_to_constant(bit, outcome, None);
         };
 
-        // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 8, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 7)?;
+    // Proving
+    // Should pass as 100 == 100
+    let mut prover = Prover::new(b"testing");
+    is_equal_gadget(prover.mut_cs(), 100, 100, true);
 
-        // Selector set to 0 should select 0
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        circuit(
-            prover.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::zero(),
-        );
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
+    prover.preprocess(&ck)?;
+    let proof = prover.prove(&ck)?;
 
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        circuit(
-            verifier.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::zero(),
-        );
-        verifier.preprocess(&ck)?;
-        // This should pass since we sent 0 as selector and the circuit closure is constraining the
-        // result to be equal to 0.
-        assert!(verifier.verify(&proof, &vk, &[BlsScalar::zero()]).is_ok());
+    // Verification
+    let mut verifier = Verifier::new(b"testing");
+    is_equal_gadget(verifier.mut_cs(), 0, 0, true);
 
-        // Selector set to 1 shouldn't assign 0.
-        // Proving
-        prover.clear_witness();
-        circuit(
-            prover.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::one(),
-        );
-        let proof = prover.prove(&ck)?;
-        // This shouldn't pass since we sent 1 as selector and the circuit closure is constraining the
-        // result to be equal to 0 while the value assigned is indeed the randomly generated one.
-        assert!(verifier.verify(&proof, &vk, &[BlsScalar::zero()]).is_err());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_conditionally_select_1() -> Result<(), Error> {
-        // The circuit closure runs the conditionally_select_one fn and constraints the result
-        // to actually to be equal to the provided expected_result.
-        let circuit = |composer: &mut StandardComposer,
-                       value: BlsScalar,
-                       selector: BlsScalar,
-                       expected_result: BlsScalar| {
-            let value = composer.add_input(value);
-            let selector = composer.add_input(selector);
-            let res = conditionally_select_one(composer, value, selector);
-            composer.constrain_to_constant(res, BlsScalar::zero(), Some(-expected_result));
-        };
-
-        // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 8, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 7)?;
-
-        // Selector set to 0 should asign 1
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        circuit(
-            prover.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::zero(),
-            BlsScalar::one(),
-        );
-        let mut pi = prover.mut_cs().construct_dense_pi_vec().clone();
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
-
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        circuit(
-            verifier.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::zero(),
-            BlsScalar::one(),
-        );
-        verifier.preprocess(&ck)?;
-        // This should pass since we sent 0 as selector and the circuit should then return
-        // 1.
-        assert!(verifier.verify(&proof, &vk, &pi).is_ok());
-
-        // Selector set to 1 should assign the randomly-generated value.
-        // Proving
-        prover.clear_witness();
-        let rand = BlsScalar::random(&mut rand::thread_rng());
-        circuit(prover.mut_cs(), rand, BlsScalar::one(), rand);
-        pi = prover.mut_cs().construct_dense_pi_vec().clone();
-        let proof = prover.prove(&ck)?;
-        // This should pass since we sent 1 as selector and the circuit closure should assign the randomly-generated
-        // value as a result.
-        verifier
-            .verify(&proof, &vk, &pi)
-            .map_err(|e| anyhow::anyhow!(e))
-    }
-
-    #[test]
-    fn test_is_not_zero() -> Result<(), Error> {
-        // The circuit closure runs the is_not_zero fn and constraints the input to
-        // not be zero.
-        let circuit = |composer: &mut StandardComposer,
-                       value: BlsScalar,
-                       value_assigned: BlsScalar|
-         -> Result<(), Error> {
-            let value = composer.add_input(value);
-            is_non_zero(composer, value, value_assigned)
-        };
-
-        // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 8, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 7)?;
-
-        // Value  & Value assigned set to 0 should err
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        assert!(circuit(prover.mut_cs(), BlsScalar::zero(), BlsScalar::zero()).is_err());
-        prover.clear_witness();
-
-        // Value and value_assigned with different values should fail on verification.
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        assert!(circuit(
-            prover.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::random(&mut rand::thread_rng()),
-        )
+    verifier.preprocess(&ck).expect("Preprocessing error");
+    assert!(verifier
+        .verify(&proof, &vk, &vec![BlsScalar::zero()])
         .is_ok());
-        let mut pi = prover.mut_cs().construct_dense_pi_vec().clone();
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
 
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        circuit(
-            verifier.mut_cs(),
-            BlsScalar::random(&mut rand::thread_rng()),
-            BlsScalar::random(&mut rand::thread_rng()),
-        )?;
-        verifier.preprocess(&ck)?;
-        assert!(verifier.verify(&proof, &vk, &pi).is_err());
+    // Proving
+    // Should fail as 20 != 3330
+    let mut prover = Prover::new(b"testing");
+    is_equal_gadget(prover.mut_cs(), 20, 3330, false);
 
-        // Value & value assigned set correctly and != 0. This should pass.
-        // Proving
-        prover.clear_witness();
-        let rand = BlsScalar::random(&mut rand::thread_rng());
-        circuit(prover.mut_cs(), rand, rand)?;
-        pi = prover.mut_cs().construct_dense_pi_vec().clone();
-        let proof = prover.prove(&ck)?;
-        // This should pass since we sent 1 as selector and the circuit closure should assign the randomly-generated
-        // value as a result.
-        verifier
-            .verify(&proof, &vk, &pi)
-            .map_err(|e| anyhow::anyhow!(e))
-    }
+    prover.preprocess(&ck)?;
+    let proof = prover.prove(&ck)?;
+
+    // Verification
+    let mut verifier = Verifier::new(b"testing");
+    is_equal_gadget(verifier.mut_cs(), 0, 0, false);
+
+    verifier.preprocess(&ck)?;
+    assert!(verifier
+        .verify(&proof, &vk, &vec![BlsScalar::zero()])
+        .is_ok());
+
+    Ok(())
+}
+
+#[test]
+fn test_conditionally_select_0() -> Result<(), Error> {
+    // The circuit closure runs the conditionally_select_zero fn and constraints the result
+    // to actually be 0
+    let circuit = |composer: &mut StandardComposer, value: BlsScalar, selector: BlsScalar| {
+        let value = composer.add_input(value);
+        let selector = composer.add_input(selector);
+        let res = conditionally_select_zero(composer, value, selector);
+        composer.constrain_to_constant(res, BlsScalar::zero(), None);
+    };
+
+    // Generate Composer & Public Parameters
+    let pub_params = PublicParameters::setup(1 << 8, &mut rand::thread_rng())?;
+    let (ck, vk) = pub_params.trim(1 << 7)?;
+
+    // Selector set to 0 should select 0
+    // Proving
+    let mut prover = Prover::new(b"testing");
+    circuit(
+        prover.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::zero(),
+    );
+    prover.preprocess(&ck)?;
+    let proof = prover.prove(&ck)?;
+
+    // Verification
+    let mut verifier = Verifier::new(b"testing");
+    circuit(
+        verifier.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::zero(),
+    );
+    verifier.preprocess(&ck)?;
+    // This should pass since we sent 0 as selector and the circuit closure is constraining the
+    // result to be equal to 0.
+    assert!(verifier.verify(&proof, &vk, &[BlsScalar::zero()]).is_ok());
+
+    // Selector set to 1 shouldn't assign 0.
+    // Proving
+    prover.clear_witness();
+    circuit(
+        prover.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::one(),
+    );
+    let proof = prover.prove(&ck)?;
+    // This shouldn't pass since we sent 1 as selector and the circuit closure is constraining the
+    // result to be equal to 0 while the value assigned is indeed the randomly generated one.
+    assert!(verifier.verify(&proof, &vk, &[BlsScalar::zero()]).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn test_conditionally_select_1() -> Result<(), Error> {
+    // The circuit closure runs the conditionally_select_one fn and constraints the result
+    // to actually to be equal to the provided expected_result.
+    let circuit = |composer: &mut StandardComposer,
+                   value: BlsScalar,
+                   selector: BlsScalar,
+                   expected_result: BlsScalar| {
+        let value = composer.add_input(value);
+        let selector = composer.add_input(selector);
+        let res = conditionally_select_one(composer, value, selector);
+        composer.constrain_to_constant(res, BlsScalar::zero(), Some(-expected_result));
+    };
+
+    // Generate Composer & Public Parameters
+    let pub_params = PublicParameters::setup(1 << 8, &mut rand::thread_rng())?;
+    let (ck, vk) = pub_params.trim(1 << 7)?;
+
+    // Selector set to 0 should asign 1
+    // Proving
+    let mut prover = Prover::new(b"testing");
+    circuit(
+        prover.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::zero(),
+        BlsScalar::one(),
+    );
+    let mut pi = prover.mut_cs().construct_dense_pi_vec().clone();
+    prover.preprocess(&ck)?;
+    let proof = prover.prove(&ck)?;
+
+    // Verification
+    let mut verifier = Verifier::new(b"testing");
+    circuit(
+        verifier.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::zero(),
+        BlsScalar::one(),
+    );
+    verifier.preprocess(&ck)?;
+    // This should pass since we sent 0 as selector and the circuit should then return
+    // 1.
+    assert!(verifier.verify(&proof, &vk, &pi).is_ok());
+
+    // Selector set to 1 should assign the randomly-generated value.
+    // Proving
+    prover.clear_witness();
+    let rand = BlsScalar::random(&mut rand::thread_rng());
+    circuit(prover.mut_cs(), rand, BlsScalar::one(), rand);
+    pi = prover.mut_cs().construct_dense_pi_vec().clone();
+    let proof = prover.prove(&ck)?;
+    // This should pass since we sent 1 as selector and the circuit closure should assign the randomly-generated
+    // value as a result.
+    verifier.verify(&proof, &vk, &pi)
+}
+
+#[test]
+fn test_is_not_zero() -> Result<(), Error> {
+    // The circuit closure runs the is_not_zero fn and constraints the input to
+    // not be zero.
+    let circuit = |composer: &mut StandardComposer,
+                   value: BlsScalar,
+                   value_assigned: BlsScalar|
+     -> Result<(), GadgetError> {
+        let value = composer.add_input(value);
+        is_non_zero(composer, value, value_assigned)
+    };
+
+    // Generate Composer & Public Parameters
+    let pub_params = PublicParameters::setup(1 << 8, &mut rand::thread_rng())?;
+    let (ck, vk) = pub_params.trim(1 << 7)?;
+
+    // Value  & Value assigned set to 0 should err
+    // Proving
+    let mut prover = Prover::new(b"testing");
+    assert!(circuit(prover.mut_cs(), BlsScalar::zero(), BlsScalar::zero()).is_err());
+    prover.clear_witness();
+
+    // Value and value_assigned with different values should fail on verification.
+    // Proving
+    let mut prover = Prover::new(b"testing");
+    assert!(circuit(
+        prover.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::random(&mut rand::thread_rng()),
+    )
+    .is_ok());
+    let mut pi = prover.mut_cs().construct_dense_pi_vec().clone();
+    prover.preprocess(&ck)?;
+    let proof = prover.prove(&ck)?;
+
+    // Verification
+    let mut verifier = Verifier::new(b"testing");
+    circuit(
+        verifier.mut_cs(),
+        BlsScalar::random(&mut rand::thread_rng()),
+        BlsScalar::random(&mut rand::thread_rng()),
+    )
+    .map_err(|_| Error::BlsScalarMalformed)?;
+    verifier.preprocess(&ck)?;
+    assert!(verifier.verify(&proof, &vk, &pi).is_err());
+
+    // Value & value assigned set correctly and != 0. This should pass.
+    // Proving
+    prover.clear_witness();
+    let rand = BlsScalar::random(&mut rand::thread_rng());
+    circuit(prover.mut_cs(), rand, rand).map_err(|_| Error::BlsScalarMalformed)?;
+    pi = prover.mut_cs().construct_dense_pi_vec().clone();
+    let proof = prover.prove(&ck)?;
+    // This should pass since we sent 1 as selector and the circuit closure should assign the randomly-generated
+    // value as a result.
+    verifier.verify(&proof, &vk, &pi)
 }


### PR DESCRIPTION
The error definitions of the crate are now more no-std friendly.

Resolves: #39 

**Merge before #40 **