### PR TITLE
Change the crate to be no_std by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Add
-- Add `std-plonk` feature to crate [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+- Add `std` feature to crate [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
 
 ### Change
 - Change crate to be `no_std` by default [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Add
+- Add `std-plonk` feature to crate [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+
+### Change
+- Change crate to be `no_std` by default [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+- Update `rand` from v0.7 to v0.8 [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+
 ### Remove
 - Remove `anyhow` and `thiserror`. [#39](https://github.com/dusk-network/plonk_gadgets/issues/39)
+- Remove `rand_core` from dev-deps [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
 
 ## [v0.5.0] - 13-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Change
 - Change crate to be `no_std` by default [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
-- Update `rand` from v0.7 to v0.8 [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
+- Update `rand` from `v0.7` to `v0.8` [#42](https://github.com/dusk-network/plonk_gadgets/issues/42)
 
 ### Remove
 - Remove `anyhow` and `thiserror`. [#39](https://github.com/dusk-network/plonk_gadgets/issues/39)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ exclude = [
 
 [dependencies]
 dusk-bytes = "0.1"
-dusk-plonk = "0.8.0-rc.1"
+dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["alloc"]}
 
 [dev-dependencies]
 rand = "0.8"
-rand_core = "0.5"
+
+[features]
+std-plonk = [
+    "dusk-plonk/std"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["all
 rand = "0.8"
 
 [features]
-std-plonk = [
+std = [
     "dusk-plonk/std"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![no_std]
+
+extern crate alloc;
 
 pub(crate) mod allocated_scalar;
 pub mod errors;

--- a/src/range.rs
+++ b/src/range.rs
@@ -191,6 +191,7 @@ fn num_bits_closest_power_of_two(scalar: BlsScalar) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn counting_scalar_bits() {
@@ -228,6 +229,6 @@ mod tests {
 
         verifier.preprocess(&ck)?;
 
-        verifier.verify(&proof, &vk, &alloc::vec![BlsScalar::zero()])
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -12,6 +12,7 @@
 //! since it will introduce less constraints to your CS.
 
 use super::{scalar::maybe_equal, AllocatedScalar};
+use alloc::vec::Vec;
 use dusk_bytes::Serializable;
 use dusk_plonk::prelude::*;
 
@@ -227,6 +228,6 @@ mod tests {
 
         verifier.preprocess(&ck)?;
 
-        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
+        verifier.verify(&proof, &vk, &alloc::vec![BlsScalar::zero()])
     }
 }


### PR DESCRIPTION
- Use `dusk-plonk` with `alloc` feature by default.
- Add `std-plonk` feature to enable std's plonk speed benefits.
- Use `Vec` & `vec!` from `alloc`.

Resolves: #42

** This should be merged before #41 **